### PR TITLE
Correct minor error in work.json

### DIFF
--- a/content/work.json
+++ b/content/work.json
@@ -3,7 +3,7 @@
     {
       "featured": true,
       "name": "Buildarmy",
-      "description": "Previously a WordPress and WooCommerce monolith, Buildarmy has been transformed into a headless e-commerce store utilising a modern open-source stack. Through hybrid rendering techniques and a decoupled architecture, the project achieves its goals of improved core web vitals and a better end-user experience for customers. Designed and developed in partial fulfilment of the requirements for the degree of BSc (Hons) Computing (Software Engineering) at The University of Northampton.The source code for my forever work-in-progress portfolio website cleverly named wiportfolio.",
+      "description": "Previously a WordPress and WooCommerce monolith, Buildarmy has been transformed into a headless e-commerce store utilising a modern open-source stack. Through hybrid rendering techniques and a decoupled architecture, the project achieves its goals of improved core web vitals and a better end-user experience for customers. Designed and developed in partial fulfilment of the requirements for the degree of BSc (Hons) Computing (Software Engineering) at The University of Northampton.",
       "lastUpdated": "2021-04-23",
       "demoLink": "https://buildarmy.vercel.app",
       "githubLink": "https://github.com/jenewland1999/buildarmy"


### PR DESCRIPTION
It looks like a sentence was duplicated from another project while creating the entry for BuildArmy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected punctuation in the Buildarmy entry by adding a missing full stop after “The University of Northampton”.
  * Improved readability by inserting appropriate spacing after the sentence boundary.

* **Documentation**
  * Streamlined the Buildarmy description by removing an extraneous clause, resulting in a clearer, more concise summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->